### PR TITLE
#18 Update tweets table partition and clustering key

### DIFF
--- a/kaftter-api/src/main/kotlin/kaftter/api/converter/TweetConverter.kt
+++ b/kaftter-api/src/main/kotlin/kaftter/api/converter/TweetConverter.kt
@@ -18,7 +18,11 @@ fun convert(summarizedTweetEntity: SummarizedTweetEntity): TweetSummary {
 }
 
 fun convert(tweet: Tweet): TweetEntity {
-    val tweetKey = TweetKey(tweet.id, tweet.user.id)
+    val tweetKey = TweetKey(
+            tweetId = tweet.id,
+            userId = tweet.user.id,
+            createdAt = tweet.createdAt
+    )
     return TweetEntity(
             key = tweetKey,
             text = tweet.text,
@@ -27,7 +31,6 @@ fun convert(tweet: Tweet): TweetEntity {
             retweetCount = tweet.retweetCount,
             favoriteCount = tweet.favoriteCount,
             language = tweet.language,
-            createdAt = tweet.createdAt,
             userName = tweet.user.name,
             userScreenName = tweet.user.screenName,
             userFollowers = tweet.user.followers

--- a/kaftter-api/src/main/kotlin/kaftter/api/domain/TweetEntity.kt
+++ b/kaftter-api/src/main/kotlin/kaftter/api/domain/TweetEntity.kt
@@ -3,7 +3,6 @@ package kaftter.api.domain
 import org.springframework.data.cassandra.core.mapping.Column
 import org.springframework.data.cassandra.core.mapping.PrimaryKey
 import org.springframework.data.cassandra.core.mapping.Table
-import java.time.LocalDateTime
 
 const val TWEETS = "tweets"
 
@@ -30,9 +29,6 @@ data class TweetEntity(
 
         @Column("language")
         val language: String,
-
-        @Column("created_at")
-        val createdAt: LocalDateTime,
 
         @Column("user_name")
         val userName: String,

--- a/kaftter-api/src/main/kotlin/kaftter/api/domain/TweetKey.kt
+++ b/kaftter-api/src/main/kotlin/kaftter/api/domain/TweetKey.kt
@@ -3,12 +3,16 @@ package kaftter.api.domain
 import org.springframework.data.cassandra.core.cql.PrimaryKeyType
 import org.springframework.data.cassandra.core.mapping.PrimaryKeyClass
 import org.springframework.data.cassandra.core.mapping.PrimaryKeyColumn
+import java.time.LocalDate
 
 @PrimaryKeyClass
 data class TweetKey(
-        @PrimaryKeyColumn(name = "tweet_id", ordinal = 0, type = PrimaryKeyType.PARTITIONED)
-        val tweetId: Long,
+        @PrimaryKeyColumn(name = "user_id", ordinal = 0, type = PrimaryKeyType.CLUSTERED)
+        val userId: Long,
 
-        @PrimaryKeyColumn(name = "user_id", ordinal = 1, type = PrimaryKeyType.CLUSTERED)
-        val userId: Long
+        @PrimaryKeyColumn("created_at", ordinal = 0, type = PrimaryKeyType.PARTITIONED)
+        val createdAt: LocalDate,
+
+        @PrimaryKeyColumn(name = "tweet_id", ordinal = 0, type = PrimaryKeyType.CLUSTERED)
+        val tweetId: Long
 )

--- a/kaftter-api/src/main/kotlin/kaftter/api/resource/AdviceResource.kt
+++ b/kaftter-api/src/main/kotlin/kaftter/api/resource/AdviceResource.kt
@@ -2,6 +2,7 @@ package kaftter.api.resource
 
 import kaftter.api.exception.UserNotFoundException
 import kaftter.api.logging.logger
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -15,4 +16,11 @@ class AdviceResource {
         logger.error("User not found", exception)
         return ResponseEntity.notFound().build<Any>()
     }
+
+    @ExceptionHandler(Exception::class)
+    fun handleUnexpectedException(exception: Exception): ResponseEntity<Any> {
+        logger.error("Undexpected exception", exception)
+        return ResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR)
+    }
+
 }

--- a/kaftter-api/src/main/kotlin/kaftter/api/vo/Tweet.kt
+++ b/kaftter-api/src/main/kotlin/kaftter/api/vo/Tweet.kt
@@ -1,7 +1,11 @@
 package kaftter.api.vo
 
 import com.fasterxml.jackson.annotation.JsonFormat
-import java.time.LocalDateTime
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer
+import java.time.LocalDate
 
 data class Tweet(
         val id: Long,
@@ -12,6 +16,8 @@ data class Tweet(
         val retweetCount: Int,
         val favoriteCount: Int,
         val language: String,
-        @get:JsonFormat(pattern = "YYYY-MM-DDThh:mm:ss")
-        val createdAt: LocalDateTime
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        @JsonDeserialize(using = LocalDateDeserializer::class)
+        @JsonSerialize(using = LocalDateSerializer::class)
+        val createdAt: LocalDate
 )

--- a/kaftter-api/src/test/kotlin/kaftter/api/service/TweetServiceTest.kt
+++ b/kaftter-api/src/test/kotlin/kaftter/api/service/TweetServiceTest.kt
@@ -16,7 +16,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
-import java.time.LocalDateTime
+import java.time.LocalDate
 import java.util.Optional
 
 @ExtendWith(MockKExtension::class)
@@ -53,13 +53,18 @@ class TweetServiceTest {
     @Test
     fun `test searching for tweet summary of existing user should return user summary`() {
         val userId = 1L
-        val summarizedTweetEntity = mockk<SummarizedTweetEntity>()
+        val summarizedTweetEntity = mockSummarizedTweetEntity(userId)
         every { summarizedTweetRepository.findByUserId(userId) } returns Optional.of(summarizedTweetEntity)
 
         val tweetSummary = tweetService.search(userId)
 
         verify { summarizedTweetRepository.findByUserId(userId) }
-        assertThat(tweetSummary).isEqualTo(summarizedTweetEntity)
+        assertThat(tweetSummary.userId).isEqualTo(summarizedTweetEntity.userId)
+        assertThat(tweetSummary.userName).isEqualTo(summarizedTweetEntity.userName)
+        assertThat(tweetSummary.favoriteCount).isEqualTo(summarizedTweetEntity.favoriteCount)
+        assertThat(tweetSummary.quoteCount).isEqualTo(summarizedTweetEntity.quoteCount)
+        assertThat(tweetSummary.replyCount).isEqualTo(summarizedTweetEntity.replyCount)
+        assertThat(tweetSummary.retweetCount).isEqualTo(summarizedTweetEntity.retweetCount)
     }
 
     private fun mockTweet(): Tweet {
@@ -71,13 +76,24 @@ class TweetServiceTest {
                 quoteCount = 2,
                 retweetCount = 0,
                 language = "en",
-                createdAt = LocalDateTime.now(),
+                createdAt = LocalDate.now(),
                 user = User(
                         id = 2,
                         followers = 0,
                         name = "none",
                         screenName = "none"
                 )
+        )
+    }
+
+    private fun mockSummarizedTweetEntity(userId: Long): SummarizedTweetEntity {
+        return SummarizedTweetEntity(
+                userId = userId,
+                userName = "john",
+                retweetCount = 0,
+                replyCount = 0,
+                quoteCount = 0,
+                favoriteCount = 0
         )
     }
 }


### PR DESCRIPTION
Update the tweets table partion key to be the user id and the creation date (only date without time) so that it'll be better for the job to summarize the information, and to keep uniqueness the tweet id is still in the primary key but as a clustering key.